### PR TITLE
Errors should be printed on stderr 

### DIFF
--- a/ged2dot.py
+++ b/ged2dot.py
@@ -848,8 +848,8 @@ class GedcomImport:
 
             # pylint: disable=broad-except
             except Exception as exc:
-                print("Encountered parsing error in .ged: " + str(exc))
-                print("line (%d): %s" % (linecount, line))
+                sys.stderr.write("Encountered parsing error in .ged: " + str(exc) + "\n")
+                sys.stderr.write("line (%d): %s\n" % (linecount, line))
                 sys.exit(1)
 
 # Configuration handling
@@ -976,7 +976,7 @@ def main() -> None:
         config = Config(sys.argv[1:])
     # pylint: disable=broad-except
     except (BaseException) as base_exception:
-        print("Configuration invalid? %s" % (str(base_exception)))
+        sys.stderr.write("Configuration invalid? %s\n" % (str(base_exception)))
         sys.exit(1)
 
     if len(sys.argv) > 1 and (sys.argv[1] == "--help" or sys.argv[1] == "-h"):

--- a/test/test.py
+++ b/test/test.py
@@ -65,7 +65,7 @@ class Test(unittest.TestCase):
     def test_nosex(self) -> None:
         # Capture standard output.
         buf = io.StringIO()
-        with unittest.mock.patch('sys.stdout', buf):
+        with unittest.mock.patch('sys.stderr', buf):
             ret = []  # type: List[int]
             with unittest.mock.patch('sys.exit', mock_sys_exit(ret)):
                 # if there is no sex, this should fail and indicate line number


### PR DESCRIPTION
Hi,
This pull request removed useles and unwanted return type for DescendantsLayout.filter_families and also made sure error are printed on stderr (and not stdout via standard print).
Regards,
Colin Chargy