### PR TITLE
Add remaining missing tests

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -14,7 +14,7 @@ test.svg: test.dot
 test.dot: core.py test.ged
 	./core.py
 
-check: check-mypy check-flake8 check-pylint #check-unit
+check: check-mypy check-flake8 check-pylint check-unit
 
 check-mypy: $(patsubst %.py,%.mypy,$(PYTHON_OBJECTS))
 

--- a/core/TODO.adoc
+++ b/core/TODO.adoc
@@ -1,3 +1,2 @@
 - don't hardcode parameters
 - user doc
-- tests

--- a/core/requirements.txt
+++ b/core/requirements.txt
@@ -1,4 +1,5 @@
 appdirs==1.4.4 # pylint dependency
+coverage==5.3.1
 flake8==3.8.4
 mypy==0.790
 packaging==20.8 # pylint dependency

--- a/core/tests/level3.ged
+++ b/core/tests/level3.ged
@@ -1,0 +1,16 @@
+0 HEAD
+0 @P1@ INDI 
+1 NAME Alice /A/
+1 SEX F
+1 FAMS @F1@
+0 @P2@ INDI 
+1 BIRT 
+2 DATE Y
+3 FOO
+1 NAME Bob /B/
+1 SEX M
+1 FAMS @F1@
+0 @F1@ FAM 
+1 HUSB @P2@
+1 WIFE @P1@
+0 TRLR

--- a/core/tests/no_surname.ged
+++ b/core/tests/no_surname.ged
@@ -1,0 +1,13 @@
+0 HEAD
+0 @P1@ INDI 
+1 NAME Alice
+1 SEX F
+1 FAMS @F1@
+0 @P2@ INDI 
+1 NAME Bob /B/
+1 SEX M
+1 FAMS @F1@
+0 @F1@ FAM 
+1 HUSB @P2@
+1 WIFE @P1@
+0 TRLR

--- a/core/tests/unexpected_date.ged
+++ b/core/tests/unexpected_date.ged
@@ -1,0 +1,15 @@
+0 HEAD
+0 @P1@ INDI 
+1 NAME Alice /A/
+1 SEX F
+1 FAMS @F1@
+0 @P2@ INDI 
+1 FOO
+2 DATE Y
+1 NAME Bob /B/
+1 SEX M
+1 FAMS @F1@
+0 @F1@ FAM 
+1 HUSB @P2@
+1 WIFE @P1@
+0 TRLR


### PR DESCRIPTION
- Test missing surname/family name
- Test that we ignore a 3rd level
- Test that we just ignore a date which is not birth/death
- Test export of a no-husband/wife model

Statement coverage goes up to 100%.

Change-Id: I8e4a9c29e5aca90331bf4291801f7a766a55f2bd
