### PR TITLE
Make sure that imagedir is relative to the gedcom's dir

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,2 +1,1 @@
-- fix images when $CWD is not the dir of the .ged file
 - libreoffice extension: flake8/pylint fixes

--- a/ged2dot.py
+++ b/ged2dot.py
@@ -64,6 +64,14 @@ def get_abspath(path: str) -> str:
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), path)
 
 
+def get_data_abspath(gedcom: str, path: str) -> str:
+    """Make a path absolute, taking the gedcom file's dir as a base dir."""
+    if os.path.isabs(path):
+        return path
+
+    return os.path.join(os.path.dirname(os.path.realpath(gedcom)), path)
+
+
 class Individual(Node):
     """An individual is always a child in a family, and is an adult in 0..* families."""
     def __init__(self) -> None:
@@ -376,8 +384,9 @@ class DotExport:
             individual = node
             stream.write(node.get_identifier() + " [shape=box, ")
             image_dir = self.config.get("imagedir", "")
+            image_dir_abs = get_data_abspath(self.config.get("input", ""), image_dir)
             name_order = self.config.get("nameorder", "little")
-            stream.write("label = <" + individual.get_label(image_dir, name_order) + ">\n")
+            stream.write("label = <" + individual.get_label(image_dir_abs, name_order) + ">\n")
             stream.write("color = " + individual.get_color() + "];\n")
 
     def __store_family_nodes(self, stream: TextIO) -> None:

--- a/tests/test_ged2dot.py
+++ b/tests/test_ged2dot.py
@@ -99,7 +99,7 @@ class TestMain(unittest.TestCase):
             "input": "tests/happy.ged",
             "output": "tests/happy.dot",
             "rootfamily": "F1",
-            "imagedir": "tests/images",
+            "imagedir": "images",
         }
         if os.path.exists(config["output"]):
             os.unlink(config["output"])
@@ -108,6 +108,23 @@ class TestMain(unittest.TestCase):
         self.assertTrue(os.path.exists(config["output"]))
         with open(config["output"], "r") as stream:
             self.assertIn("images/", stream.read())
+
+    def test_image_abspath(self) -> None:
+        """Tests the case when imagedir is an abs path already."""
+        config = {
+            "familydepth": "4",
+            "input": "tests/happy.ged",
+            "output": "tests/image-abspath.dot",
+            "rootfamily": "F1",
+            "imagedir": os.path.join(os.getcwd(), "tests/images"),
+        }
+        if os.path.exists(config["output"]):
+            os.unlink(config["output"])
+        self.assertFalse(os.path.exists(config["output"]))
+        ged2dot.convert(config)
+        self.assertTrue(os.path.exists(config["output"]))
+        with open(config["output"], "r") as stream:
+            self.assertIn(config["imagedir"], stream.read())
 
     def test_config(self) -> None:
         """Tests the case when there is a ged2dotrc in the current dir."""


### PR DESCRIPTION
In case CWD, dir(ged2dot.py) and dir(input.ged) are 3 different dirs, we
already handled placeholders relative to dir(ged2dot.py).

Be consistent and handle real images relative to dir(input.ged).

Change-Id: I2ad2105c947b4d8163d7446c5db87e1751edb5ca
