### PR TITLE
qt: png/dot should be a save dialog

### DIFF
--- a/qged2dot.py
+++ b/qged2dot.py
@@ -76,7 +76,7 @@ class Widgets:
     def set_output(self) -> None:
         """Handler for the output button."""
         dialog = QFileDialog()
-        dialog.setFileMode(QFileDialog.AnyFile)
+        dialog.setAcceptMode(QFileDialog.AcceptSave)
         name_filters = [
             "PNG files (*.png)",
             "Graphviz files (*.dot)",


### PR DESCRIPTION
This just had the wrong button title on Linux (which I didn't notice),
but it just doesn't allow specifying a filename on macOS.

Change-Id: I90a9d9f90c79928ff90ccdb8ed412611c87265ca
