### PR TITLE
qged2dot: kill last place where we opened a file in non-binary mode

### DIFF
--- a/ged2dot.py
+++ b/ged2dot.py
@@ -253,7 +253,7 @@ class Individual(Node):
         """Gets the graphviz label."""
         image_path = os.path.join(image_dir, self.get_forename() + " " + self.get_surname())
         image_path += " " + self.get_config().get_birth() + ".jpg"
-        if not os.path.exists(image_path):
+        if not os.path.exists(to_bytes(image_path)):
             if self.get_sex():
                 sex = self.get_sex().lower()
             else:

--- a/qged2dot.py
+++ b/qged2dot.py
@@ -143,8 +143,8 @@ class Widgets:
             dot_binary_path = "/usr/local/bin/dot"
         graphviz = subprocess.Popen([dot_binary_path, "-Tpng"], stdin=subprocess.PIPE, stdout=subprocess.PIPE)
         assert graphviz.stdin
-        with open(dot_path, "r") as text_stream:
-            graphviz.stdin.write(text_stream.read().encode("utf-8"))
+        with open(dot_path, "rb") as text_stream:
+            graphviz.stdin.write(text_stream.read())
         graphviz.stdin.close()
         assert graphviz.stdout
         with open(png_path, "wb") as bin_stream:


### PR DESCRIPTION
Which would mean implicitly decoding with the system-default charset,
which is ascii on macOS.

Change-Id: Ifb0cba9f40557972c8fd248ee5e6613cf94a0dfd
