### PR TITLE
qged2dot: give up on bundling dot for now

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -50,6 +50,11 @@ For macOS:
 
 - You need to install https://brew.sh/[brew], then `dot` itself with `brew install graphviz`.
 
+For Windows:
+
+- You need to install https://chocolatey.org/[choco], then `dot` itself with `choco install
+  graphviz`.
+
 The app icon is by https://icon-icons.com/icon/family-tree/120659[Appzgear].
 
 == LibreOffice Draw GEDCOM import filter

--- a/tools/pack.bat
+++ b/tools/pack.bat
@@ -5,6 +5,4 @@ pyinstaller ^
     --add-data="placeholder-f.png;." ^
     --add-data="placeholder-m.png;." ^
     --add-data="placeholder-u.png;." ^
-    --add-binary="graphviz/bin/dot.exe;." ^
     qged2dot.py
-copy /y graphviz\bin\*.* dist\qged2dot


### PR DESCRIPTION
Similar to macOS, let the platform package manager install it instead.

This way pyinstaller now produces a working installation set, just need
to zip it up, which is a manual action for now.

Change-Id: Ia6d6c87a78fd09bb8574b6557abfc8187caf999c
