### PR TITLE
qged2dot: default to familydepth==3

### DIFF
--- a/qged2dot.py
+++ b/qged2dot.py
@@ -206,7 +206,7 @@ class Application:
         rootfamily_key = QLabel(self.window)
         rootfamily_key.setText("Family depth:")
         self.grid_layout.addWidget(rootfamily_key, 3, 0)
-        self.widgets.familydepth_value.setValue(4)
+        self.widgets.familydepth_value.setValue(3)
         self.grid_layout.addWidget(self.widgets.familydepth_value, 3, 1)
 
     def setup_imagedir(self) -> None:


### PR DESCRIPTION
It seems 0..3 typically results in almost no edges, larger values don't
provide that.

Change-Id: I73a0ccab9219ce824458bbba1ee579602242d355
