### PR TITLE
ged2dot: default to familydepth==3

### DIFF
--- a/ged2dot.py
+++ b/ged2dot.py
@@ -26,7 +26,7 @@ class Config:
         self.rootfamily = "F1"
         # Could be 0, but defaulting to something that can easily explode on large input is not
         # helpful.
-        self.familydepth = "4"
+        self.familydepth = "3"
         self.imagedir = "images"
         self.nameorder = "little"
 

--- a/tests/test_ged2dot.py
+++ b/tests/test_ged2dot.py
@@ -335,7 +335,7 @@ class TestMain(unittest.TestCase):
     def test_config_familydepth_default(self) -> None:
         """Tests config: familydepth: default."""
         def mock_convert(config: Dict[str, str]) -> None:
-            self.assertEqual(config["familydepth"], "4")
+            self.assertEqual(config["familydepth"], "3")
         argv = [""]
         with unittest.mock.patch('sys.argv', argv):
             with unittest.mock.patch('ged2dot.convert', mock_convert):


### PR DESCRIPTION
qged2dot already did this

Change-Id: Ie1f522a766cc28779429181f8ae1922f7cdded7d
