### PR TITLE
Support both \r\n and \n

### DIFF
--- a/ged2dot.py
+++ b/ged2dot.py
@@ -440,7 +440,7 @@ class GedcomImport:
 
     def tokenize_from_stream(self, stream: BinaryIO) -> List[Node]:
         """Tokenizes a gedcom steam into a graph."""
-        for line_bytes in stream.read().split(b"\r\n"):
+        for line_bytes in stream.readlines():
             line = line_bytes.strip().decode("utf-8")
             if not line:
                 continue

--- a/ged2dot.py
+++ b/ged2dot.py
@@ -440,7 +440,11 @@ class GedcomImport:
 
     def tokenize_from_stream(self, stream: BinaryIO) -> List[Node]:
         """Tokenizes a gedcom steam into a graph."""
-        for line_bytes in stream.readlines():
+        stream_buf = stream.read()
+        lines = stream_buf.split(b"\r\n")
+        if b"\r" not in stream_buf:
+            lines = stream_buf.split(b"\n")
+        for line_bytes in lines:
             line = line_bytes.strip().decode("utf-8")
             if not line:
                 continue

--- a/tests/no-cr.ged
+++ b/tests/no-cr.ged
@@ -1,0 +1,13 @@
+0 HEAD
+0 @P1@ INDI 
+1 NAME Alice /A/
+1 SEX F
+1 FAMS @F1@
+0 @P2@ INDI 
+1 NAME Bob /B/
+1 SEX M
+1 FAMS @F1@
+0 @F1@ FAM 
+1 HUSB @P2@
+1 WIFE @P1@
+0 TRLR

--- a/tests/test_ged2dot.py
+++ b/tests/test_ged2dot.py
@@ -424,6 +424,20 @@ class TestMain2(unittest.TestCase):
         assert isinstance(person, ged2dot.Individual)
         self.assertEqual(person.get_config().get_note(), "This is a note with\n3\nlines")
 
+    def test_no_cr(self) -> None:
+        """Tests the case when the file contains no \r."""
+        config = {
+            "familydepth": "4",
+            "input": "tests/no-cr.ged",
+            "output": "tests/no-cr.dot",
+            "rootfamily": "F1",
+        }
+        if os.path.exists(config["output"]):
+            os.unlink(config["output"])
+        self.assertFalse(os.path.exists(config["output"]))
+        ged2dot.convert(config)
+        self.assertTrue(os.path.exists(config["output"]))
+
 
 class TestGetAbspath(unittest.TestCase):
     """Tests get_abspath()."""


### PR DESCRIPTION
Python3 use "universal newlines" so users shouldn't have to care.