### PR TITLE
Keep aspect ratio of images in the PDF output with long names

### DIFF
--- a/NEWS.adoc
+++ b/NEWS.adoc
@@ -3,6 +3,7 @@
 == master
 
 - Better support for GenoPro-generated GED files (Andreas Hrubak)
+- Keep aspect ratio of images in the PDF output with long names (humaita)
 
 == 7.1
 

--- a/ged2dot.py
+++ b/ged2dot.py
@@ -260,7 +260,7 @@ class Individual(Node):
                 sex = 'u'
             image_path = get_abspath("placeholder-%s.png" % sex)
         label = "<table border=\"0\" cellborder=\"0\"><tr><td>"
-        label += "<img src=\"" + image_path + "\"/>"
+        label += "<img scale=\"true\" src=\"" + image_path + "\"/>"
         label += "</td></tr><tr><td>"
         if name_order == "big":
             # Big endian: family name first.


### PR DESCRIPTION
PNG output was fine without this already and is unchanged.

This is 1) of <https://github.com/vmiklos/ged2dot/issues/170>.

Patch-by: humaita
Change-Id: I66cbcc0a48b78dacc1e92a41d92940a3d54c8272
