### PR TITLE
Add --birthformat option

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -13,5 +13,8 @@ max-line-length=120
 # Minimum number of public methods for a class (see R0903).
 min-public-methods=0
 
+# Default: 7.
+max-attributes=14
+
 [MASTER]
 extension-pkg-whitelist=PyQt5

--- a/tests/test_ged2dot.py
+++ b/tests/test_ged2dot.py
@@ -28,7 +28,7 @@ class TestIndividual(unittest.TestCase):
         individual = ged2dot.graph_find(graph, "P3")
         assert individual
         assert isinstance(individual, ged2dot.Individual)
-        self.assertIn("placeholder-u", individual.get_label("tests/images", "little", basepath=""))
+        self.assertIn("placeholder-u", individual.get_label("tests/images", "little", "{}-", basepath=""))
         self.assertEqual(individual.get_color(), "black")
 
     def test_big_endian_name(self) -> None:
@@ -41,7 +41,8 @@ class TestIndividual(unittest.TestCase):
         individual = ged2dot.graph_find(graph, "P1")
         assert individual
         assert isinstance(individual, ged2dot.Individual)
-        self.assertIn("A<br/>Alice", individual.get_label(image_dir="", name_order="big", basepath=""))
+        label = individual.get_label(image_dir="", name_order="big", birth_format="{}-", basepath="")
+        self.assertIn("A<br/>Alice", label)
 
     def test_str(self) -> None:
         """Tests __str()__."""
@@ -377,11 +378,11 @@ class TestMain(unittest.TestCase):
             with unittest.mock.patch('ged2dot.convert', mock_convert):
                 ged2dot.main()
 
-    def test_config_nameorder_custom(self) -> None:
-        """Tests config: nameorder: custom."""
+    def test_config_birthformat_custom(self) -> None:
+        """Tests config: birthformat: custom."""
         def mock_convert(config: Dict[str, str]) -> None:
-            self.assertEqual(config["nameorder"], "big")
-        argv = ["", "--nameorder", "big"]
+            self.assertEqual(config["birthformat"], "* {}")
+        argv = ["", "--birthformat", "* {}"]
         with unittest.mock.patch('sys.argv', argv):
             with unittest.mock.patch('ged2dot.convert', mock_convert):
                 ged2dot.main()
@@ -480,6 +481,15 @@ class TestMain2(unittest.TestCase):
         self.assertTrue(os.path.exists(config["output"]))
         with open(config["output"], "r") as stream:
             self.assertIn("† Y", stream.read())
+
+    def test_config_nameorder_custom(self) -> None:
+        """Tests config: nameorder: custom."""
+        def mock_convert(config: Dict[str, str]) -> None:
+            self.assertEqual(config["nameorder"], "big")
+        argv = ["", "--nameorder", "big"]
+        with unittest.mock.patch('sys.argv', argv):
+            with unittest.mock.patch('ged2dot.convert', mock_convert):
+                ged2dot.main()
 
 
 class TestGetAbspath(unittest.TestCase):


### PR DESCRIPTION
We still default to e.g. "1942-", but this allows specifying

	--birthformat '* {}'

to do what was requested in the issue, trying to make everyone happy.

Related to 4) of <https://github.com/vmiklos/ged2dot/issues/170>.

Change-Id: Iebcf1a810eff36effd4f3ca96b55072e68823879
