### PR TITLE
mypy: check all modules together

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,8 @@ all:
 check: check-mypy check-flake8 check-pylint check-unit
 	@echo "make check: ok"
 
-check-mypy: $(patsubst %.py,%.mypy,$(PYTHON_OBJECTS))
+check-mypy: $(PYTHON_OBJECTS)
+	env PYTHONPATH=.:tests mypy --python-version 3.6 --strict --no-error-summary $(PYTHON_OBJECTS) && touch $@
 
 check-flake8: $(patsubst %.py,%.flake8,$(PYTHON_OBJECTS))
 


### PR DESCRIPTION
The old approach tried to check the changed modules, but this resulted
in hiding some errors in incremental builds. check-mypy takes a few
seconds only, it's better to just check all modules all the time.

Change-Id: I83c873ea9fa974b6aa5917d8124bf6d213434202
