### PR TITLE
dot export: fix non-centered marriage icon when no date is given

### DIFF
--- a/ged2dot.py
+++ b/ged2dot.py
@@ -563,7 +563,12 @@ class DotExport:
             if self.config.get("relpath", "false") == "true" and self.config["output"] != "-":
                 basepath = os.path.dirname(os.path.abspath(self.config["output"]))
                 image_path = os.path.relpath(image_path, basepath)
-            label = "<table border=\"0\" cellborder=\"0\"><tr><td><img src=\"" + image_path + "\"/></td></tr></table>"
+
+            # Emit explicit size from marriage.svg, otherwise it won't be centered in the PNG
+            # output.
+            table_start = "<table border=\"0\" cellborder=\"0\" width=\"32px\" height=\"23px\">"
+
+            label = table_start + "<tr><td><img src=\"" + image_path + "\"/></td></tr></table>"
             if node.get_marr():
                 label = node.get_marr()
             stream.write(to_bytes(node.get_identifier() + " [shape=circle, margin=\"0,0\", label=<" + label + ">];\n"))


### PR DESCRIPTION
Explicitly specify the height/width from the SVG, this is needed for the
PNG output.

See
<https://github.com/vmiklos/ged2dot/issues/179#issuecomment-992038773>.

Change-Id: Icb7b2e20f0556624a8c59e1c79285f68fcb1a858
