### PR TITLE
qged2dot: fix typo, % was unwanted before F<num>

### DIFF
--- a/qged2dot.py
+++ b/qged2dot.py
@@ -75,7 +75,7 @@ class Widgets:
                 help_string += "-"
                 if node.wife and node.wife.get_surname():
                     help_string += node.wife.get_surname()
-                key = f"%{node.get_identifier()} ({help_string})"
+                key = f"{node.get_identifier()} ({help_string})"
                 self.rootfamily_value.addItem(key, node.get_identifier())
             self.update_status()
         except Exception:  # pylint: disable=broad-except


### PR DESCRIPTION
Regression from commit 1f1c3755f07cb9b971d10dda93f1819269f6c63f (Update
pylint to 2.12.2, 2021-12-22).

Change-Id: I94d3492ffe84aa742c43054ff0da8d44b743fa11
