### PR TITLE
Fail nicer when the specified root family doesn't exist

### DIFF
--- a/ged2dot.py
+++ b/ged2dot.py
@@ -114,6 +114,9 @@ def graph_find(graph: List[Node], identifier: str) -> Optional[Node]:
         return None
 
     results = [node for node in graph if node.get_identifier() == identifier]
+    if not results:
+        return None
+
     assert len(results) == 1
     return results[0]
 
@@ -618,7 +621,17 @@ def convert(config: Dict[str, str]) -> None:
     importer = GedcomImport()
     graph = importer.load(config)
     root_family = graph_find(graph, config["rootfamily"])
-    assert root_family
+    if not root_family:
+        family_id = ""
+        for node in graph:
+            if not isinstance(node, Family):
+                continue
+            family_id = node.get_identifier()
+            break
+        reason = f"Root family '{config['rootfamily']}' is not found."
+        if family_id:
+            reason += f" First valid family would be '{family_id}'."
+        raise Exception(reason)
     subgraph = bfs(root_family, config)
     exporter = DotExport()
     exporter.store(subgraph, config)

--- a/tests/empty.ged
+++ b/tests/empty.ged
@@ -1,0 +1,10 @@
+0 HEAD
+1 CHAR UTF-8
+1 SOUR Ancestry.com Family Trees
+2 VERS (2010.3)
+2 NAME Ancestry.com Family Trees
+2 CORP Ancestry.com
+1 GEDC
+2 VERS 5.5
+2 FORM LINEAGE-LINKED
+0 TRLR

--- a/tests/test_ged2dot.py
+++ b/tests/test_ged2dot.py
@@ -28,6 +28,8 @@ class TestIndividual(unittest.TestCase):
         }
         importer = ged2dot.GedcomImport()
         graph = importer.tokenize(config)
+        individual = ged2dot.graph_find(graph, "42")
+        assert individual is None
         individual = ged2dot.graph_find(graph, "P3")
         assert individual
         assert isinstance(individual, ged2dot.Individual)
@@ -540,6 +542,36 @@ class TestMain2(unittest.TestCase):
         root = tree.getroot()
         self.assertIn("width", root.attrib)
         self.assertIn("height", root.attrib)
+
+    def test_bad_rootfamily(self) -> None:
+        """Tests the happy path."""
+        config = {
+            "familydepth": "4",
+            "input": "tests/happy.ged",
+            "output": "tests/happy.dot",
+            "rootfamily": "42",
+            "imagedir": "images",
+        }
+        if os.path.exists(config["output"]):
+            os.unlink(config["output"])
+        self.assertFalse(os.path.exists(config["output"]))
+        with self.assertRaises(Exception):
+            ged2dot.convert(config)
+
+    def test_bad_rootfamily_empty_graph(self) -> None:
+        """Tests the happy path."""
+        config = {
+            "familydepth": "4",
+            "input": "tests/empty.ged",
+            "output": "tests/empty.dot",
+            "rootfamily": "42",
+            "imagedir": "images",
+        }
+        if os.path.exists(config["output"]):
+            os.unlink(config["output"])
+        self.assertFalse(os.path.exists(config["output"]))
+        with self.assertRaises(Exception):
+            ged2dot.convert(config)
 
 
 class TestGetAbspath(unittest.TestCase):


### PR DESCRIPTION
Sample output:

	Exception: Root family 'F1' is not found. First valid family would be '41'.

Related to <https://github.com/vmiklos/ged2dot/issues/201>.

Change-Id: I06ef7898e8306361bfe883fe7d926ed2ce8e3379
