### PR TITLE
libreoffice: bump version numbers

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -69,7 +69,7 @@ Its dependencies:
 
   * For macOS, install it from https://brew.sh/[brew] (2.36 is tested).
 
-- LibreOffice >= 6.1
+- LibreOffice >= 7.2
 
 Features:
 

--- a/libreoffice/HACKING
+++ b/libreoffice/HACKING
@@ -19,7 +19,7 @@ http://wiki.documentfoundation.org/Installing_in_parallel#Step_4_-_Optional.2C_b
 Then you can use something like:
 
 ----
-make -s install UNOPKG_PREFIX=$HOME/git/libreoffice/lo71/opt/libreoffice7.1/program/
+make -s install UNOPKG_PREFIX=$HOME/git/libreoffice/lo73/opt/libreoffice7.3/program/
 ----
 
 To package and install your changes in a few seconds, with a single


### PR DESCRIPTION
- require the oldest version upstream still supports

- test with the newer version

Change-Id: I0d738252a94d3de2f3d542bd1d56efefe6a23244
