### PR TITLE
libreoffice: avoid type hints as comments for variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ check: check-mypy check-flake8 check-pylint check-unit
 	@echo "make check: ok"
 
 check-mypy: $(PYTHON_OBJECTS) Makefile requirements.txt
-	env PYTHONPATH=.:tests mypy --python-version 3.9 --strict --no-error-summary $(PYTHON_OBJECTS) && touch $@
+	env PYTHONPATH=.:tests mypy --python-version 3.8 --strict --no-error-summary $(PYTHON_OBJECTS) && touch $@
 
 check-flake8: $(patsubst %.py,%.flake8,$(PYTHON_OBJECTS))
 

--- a/libreoffice/dialog.py
+++ b/libreoffice/dialog.py
@@ -31,11 +31,11 @@ class GedcomDialog(unohelper.Base, XPropertyAccess, XExecutableDialog, XImporter
     def __init__(self, context: Any, _dialogArgs: Any) -> None:
         unohelper.Base.__init__(self)
         base.GedcomBase.__init__(self, context)
-        self.family_dict = {}  # type: Dict[str, ged2dot.Family]
-        self.root_family = None  # type: Optional[str]
+        self.family_dict: Dict[str, ged2dot.Family] = {}
+        self.root_family: Optional[str] = None
         self.layout_max = "4"
         self.name_order = "little"
-        self.props = {}  # type: Dict[str, Any]
+        self.props: Dict[str, Any] = {}
 
     def __extract_families(self) -> None:
         ged = unohelper.fileUrlToSystemPath(self.props['URL'])

--- a/libreoffice/importer.py
+++ b/libreoffice/importer.py
@@ -36,7 +36,7 @@ class GedcomImport(unohelper.Base, XFilter, XImporter, XExtendedFilterDetection,
     def __init__(self, context: Any) -> None:
         unohelper.Base.__init__(self)
         base.GedcomBase.__init__(self, context)
-        self.props = {}  # type: Dict[str, Any]
+        self.props: Dict[str, Any] = {}
         self.dst_doc = None
 
     @staticmethod

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 coverage==6.5.0
-flake8==5.0.4
+flake8==6.0.0
 mypy==0.982
 pygraphviz==1.10
 pyinstaller==5.3


### PR DESCRIPTION
Newer flake8 doesn't see them and libreoffice bundles 3.8 anyway today
(towards 7.5).

Change-Id: I672e46a5d06492c99112a6e69f3cdcb1ff30b691
