### PR TITLE
Fix unexpected ValueError when the root family is not found

### DIFF
--- a/ged2dot.py
+++ b/ged2dot.py
@@ -649,7 +649,7 @@ def convert(config: Dict[str, str]) -> None:
         reason = f"Root family '{config['rootfamily']}' is not found."
         if family_id:
             reason += f" First valid family would be '{family_id}'."
-        raise ValueError(reason)
+        raise Ged2DotException(reason)
     subgraph = bfs(root_family, config)
     exporter = DotExport()
     exporter.store(subgraph, config)

--- a/guide/src/news.md
+++ b/guide/src/news.md
@@ -1,5 +1,9 @@
 # Version descriptions
 
+## master
+
+- Fix crash on non-existing root family
+
 ## 7.6
 
 - Fix crash on non-int line start

--- a/tools/fuzz.py
+++ b/tools/fuzz.py
@@ -13,15 +13,25 @@ with atheris.instrument_imports():
     import ged2dot
     import io
     import sys
+    import unittest.mock
+
+
+class BufferHolder:
+    """Mock for sys.stdin."""
+    def __init__(self) -> None:
+        self.buffer = io.BytesIO()
 
 
 def test_one_input(data: bytes) -> None:
     """Tests one particular input."""
-    importer = ged2dot.GedcomImport()
-    try:
-        importer.tokenize_from_stream(io.BytesIO(data))
-    except ged2dot.Ged2DotException:
-        pass
+    stdin = BufferHolder()
+    stdin.buffer.write(data)
+    stdin.buffer.seek(0)
+    with unittest.mock.patch('sys.stdin', stdin):
+        try:
+            ged2dot.main()
+        except ged2dot.Ged2DotException:
+            pass
 
 
 atheris.Setup(sys.argv, test_one_input)


### PR DESCRIPTION
The expectation is only Ged2DotException is thrown, to be in sync with
the safe_*() functions.

Change-Id: I0717cd054da37df2e85f6cf2b4da4096189f6f38
